### PR TITLE
Fetch missions - Fetch data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     - [Tech Stack](#tech-stack)
     - [Key Features](#key-features)
   - [🚀 Live Demo](#live-demo)
-- [💻 Getting Started](#getting-started)
+- [💻 Getting Started](#getting-started) 
   - [Setup](#setup)
   - [Prerequisites](#prerequisites)
   - [Install](#install)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^6.12.0",
     "react-scripts": "5.0.1",
     "redux-logger": "^3.0.6",
+    "redux-thunk": "^2.4.2",
     "web-vitals": "^2.1.4"
   },
   "homepage": "http://MarcoDiaz2000.github.io/space-travelers-hub",

--- a/src/components/missions/Missions.js
+++ b/src/components/missions/Missions.js
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchMissions } from '../../redux/missions/missionsSlice';
+
+const Missions = () => {
+  const dispatch = useDispatch();
+  const missions = useSelector((state) => state.missions);
+
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, [dispatch]);
+
+  return (
+    <div>
+      <h1>Missions</h1>
+      {missions.map((mission) => (
+        <div key={mission.missionId}>
+          <h2>{mission.missionName}</h2>
+          <p>{mission.description}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Missions;

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,0 +1,22 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export const fetchMissions = createAsyncThunk('missions/fetchMissions', async () => {
+  const response = await axios.get('https://api.spacexdata.com/v3/missions');
+  return response.data.map(({ mission_id: missionId, mission_name: missionName, description }) => ({
+    missionId,
+    missionName,
+    description,
+  }));
+});
+
+const missionsSlice = createSlice({
+  name: 'missions',
+  initialState: [],
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchMissions.fulfilled, (state, action) => action.payload);
+  },
+});
+
+export default missionsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
+import missionsReducer from './missions/missionsSlice';
 
 export default configureStore({
   reducer: {
-
+    missions: missionsReducer,
   },
 });

--- a/src/router/Missions.js
+++ b/src/router/Missions.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import MissionsComponent from '../components/missions/Missions';
 
 const Missions = () => (
   <div>
-    <h1>Missions</h1>
+    <MissionsComponent />
   </div>
 );
 


### PR DESCRIPTION
I obtained data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.

Once the data are fetched, dispatch an action to store the selected data in Redux store:

mission_id
mission_name
description
NOTE: Make sure you only dispatch those actions once and do not add data to store on every re-render (i.e. when changing views / using navigation).