### PR TITLE
Implement mission joining and leave actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [📖 About the Project](#about-project) 
   - [🛠 Built With](#built-with)
     - [Tech Stack](#tech-stack) 
-    - [Key Features](#key-features)
+    - [Key Features](#key-features) 
   - [🚀 Live Demo](#live-demo)
 - [💻 Getting Started](#getting-started)
   - [Setup](#setup)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [📖 About the Project](#about-project) 
   - [🛠 Built With](#built-with) 
     - [Tech Stack](#tech-stack) 
-    - [Key Features](#key-features) 
+    - [Key Features](#key-features)
   - [🚀 Live Demo](#live-demo)
 - [💻 Getting Started](#getting-started)
   - [Setup](#setup)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # 📗 Table of Contents 
 
 - [📖 About the Project](#about-project) 
-  - [🛠 Built With](#built-with)
+  - [🛠 Built With](#built-with) 
     - [Tech Stack](#tech-stack) 
     - [Key Features](#key-features) 
   - [🚀 Live Demo](#live-demo)

--- a/src/components/missions/Mission.js
+++ b/src/components/missions/Mission.js
@@ -1,12 +1,18 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission, leaveMission } from '../../redux/missions/missionsSlice';
 import '../../styles/Mission.css';
 
 const Mission = ({ mission }) => {
-  const [isActive, setIsActive] = useState(false);
+  const dispatch = useDispatch();
 
   const handleClick = () => {
-    setIsActive(!isActive);
+    if (mission.reserved) {
+      dispatch(leaveMission(mission.missionId));
+    } else {
+      dispatch(joinMission(mission.missionId));
+    }
   };
 
   return (
@@ -14,13 +20,13 @@ const Mission = ({ mission }) => {
       <td className="col1">{mission.missionName}</td>
       <td className="col2">{mission.description}</td>
       <td className="col3">
-        <button type="button" className={`membership-button ${isActive ? 'active' : ''}`}>
-          {isActive ? 'Active Member' : 'Not a Member'}
+        <button type="button" className={`membership-button ${mission.reserved ? 'active' : ''}`}>
+          {mission.reserved ? 'Active Member' : 'Not a Member'}
         </button>
       </td>
       <td className="col4">
-        <button type="button" onClick={handleClick} className={`join-button ${isActive ? 'active' : ''}`}>
-          {isActive ? 'Leave Mission' : 'Join Mission'}
+        <button type="button" onClick={handleClick} className={`join-button ${mission.reserved ? 'active' : ''}`}>
+          {mission.reserved ? 'Leave Mission' : 'Join Mission'}
         </button>
       </td>
     </tr>
@@ -29,8 +35,10 @@ const Mission = ({ mission }) => {
 
 Mission.propTypes = {
   mission: PropTypes.shape({
+    missionId: PropTypes.string,
     missionName: PropTypes.string,
     description: PropTypes.string,
+    reserved: PropTypes.bool,
   }).isRequired,
 };
 

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -15,18 +15,18 @@ const missionsSlice = createSlice({
   name: 'missions',
   initialState: [],
   reducers: {
-    joinMission: (state, action) => {
-      const mission = state.find((mission) => mission.missionId === action.payload);
-      if (mission) {
-        mission.reserved = true;
+    joinMission: (state, action) => state.map((mission) => {
+      if (mission.missionId === action.payload) {
+        return { ...mission, reserved: true };
       }
-    },
-    leaveMission: (state, action) => {
-      const mission = state.find((mission) => mission.missionId === action.payload);
-      if (mission) {
-        mission.reserved = false;
+      return mission;
+    }),
+    leaveMission: (state, action) => state.map((mission) => {
+      if (mission.missionId === action.payload) {
+        return { ...mission, reserved: false };
       }
-    },
+      return mission;
+    }),
   },
   extraReducers: (builder) => {
     builder.addCase(fetchMissions.fulfilled, (state, action) => action.payload);

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -7,16 +7,32 @@ export const fetchMissions = createAsyncThunk('missions/fetchMissions', async ()
     missionId,
     missionName,
     description,
+    reserved: false,
   }));
 });
 
 const missionsSlice = createSlice({
   name: 'missions',
   initialState: [],
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const mission = state.find((mission) => mission.missionId === action.payload);
+      if (mission) {
+        mission.reserved = true;
+      }
+    },
+    leaveMission: (state, action) => {
+      const mission = state.find((mission) => mission.missionId === action.payload);
+      if (mission) {
+        mission.reserved = false;
+      }
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(fetchMissions.fulfilled, (state, action) => action.payload);
   },
 });
+
+export const { joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
**### Implement mission joining and leave actions**

**Implement mission joining** 
- When a user clicks the "Join Mission" button, an action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true. You could use a JS filter() or map() to set the value of the new state.
**Implement mission Leave** 
- Follow the same logic as with the "Join mission" - but you need to set the reserved key to false.
- Dispatch these actions upon click on the corresponding buttons.

